### PR TITLE
Add load average monitoring for CPU contention detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,14 @@ limit or network usage reaches ~10 Mbps on E2 (or 0.2 Gbps per A1 vCPU).
 
 `loadshaper` monitors system load average to detect CPU contention from other
 processes. When the 1-minute load average per core exceeds the configured 
-threshold (default 0.8), CPU workers are automatically paused to yield resources
+threshold (default 0.6), CPU workers are automatically paused to yield resources
 to legitimate workloads. Workers resume when load drops below the resume 
-threshold (default 0.5). This ensures `loadshaper` remains unobtrusive and
+threshold (default 0.4). This ensures `loadshaper` remains unobtrusive and
 immediately steps aside when real work needs the CPU.
+
+The default thresholds (0.6/0.4) provide a good balance between responsiveness
+to legitimate workloads and stability. The hysteresis gap prevents oscillation
+when load hovers near the threshold.
 
 ## Overriding detection and thresholds
 
@@ -74,8 +78,11 @@ NET_SENSE_MODE=container NET_LINK_MBIT=10000 NET_STOP_PCT=20 python -u loadshape
 # Raise CPU target while lowering the safety stop
 CPU_TARGET_PCT=50 CPU_STOP_PCT=70 MEM_TARGET_PCT=40 MEM_STOP_PCT=80 python -u loadshaper.py
 
-# Configure load average monitoring thresholds
+# Configure load average monitoring thresholds (more aggressive example)
 LOAD_THRESHOLD=1.0 LOAD_RESUME_THRESHOLD=0.6 LOAD_CHECK_ENABLED=true python -u loadshaper.py
+
+# Conservative load monitoring (earlier pause, safer for shared systems)
+LOAD_THRESHOLD=0.4 LOAD_RESUME_THRESHOLD=0.2 python -u loadshaper.py
 ```
 
 ## Future work

--- a/loadshaper.py
+++ b/loadshaper.py
@@ -33,8 +33,8 @@ CONTROL_PERIOD    = getenv_float("CONTROL_PERIOD_SEC", 5.0)
 AVG_WINDOW_SEC    = getenv_float("AVG_WINDOW_SEC", 300.0)
 HYSTERESIS_PCT    = getenv_float("HYSTERESIS_PCT", 5.0)
 
-LOAD_THRESHOLD    = getenv_float("LOAD_THRESHOLD", 0.8)      # pause when load avg per core > this
-LOAD_RESUME_THRESHOLD = getenv_float("LOAD_RESUME_THRESHOLD", 0.5)  # resume when load avg per core < this
+LOAD_THRESHOLD    = getenv_float("LOAD_THRESHOLD", 0.6)      # pause when load avg per core > this (conservative for Oracle Free Tier)
+LOAD_RESUME_THRESHOLD = getenv_float("LOAD_RESUME_THRESHOLD", 0.4)  # resume when load avg per core < this (hysteresis)
 LOAD_CHECK_ENABLED = os.getenv("LOAD_CHECK_ENABLED", "true").strip().lower() == "true"
 
 JITTER_PCT        = getenv_float("JITTER_PCT", 10.0)
@@ -129,9 +129,9 @@ def read_loadavg():
             load_1min = float(parts[0])
             load_5min = float(parts[1]) 
             load_15min = float(parts[2])
-            # Use N_WORKERS for consistency with actual worker thread behavior
-            # This ensures load thresholds correspond to the CPU resources loadshaper uses
-            cpu_count = N_WORKERS
+            # Use actual system CPU count since load averages are system-wide metrics
+            # that include all processes, not just loadshaper's worker threads
+            cpu_count = os.cpu_count() or 1
             per_core_load = load_1min / cpu_count if cpu_count > 0 else load_1min
             return load_1min, load_5min, load_15min, per_core_load
     except Exception:


### PR DESCRIPTION
## Summary
• Add lightweight monitor that checks system load average and pauses CPU workers when contention is detected
• Workers automatically yield to legitimate workloads when system load indicates CPU contention  
• Maintains loadshaper's unobtrusive behavior while meeting Oracle utilization requirements

## Key Changes
• **Load Average Monitoring**: New `read_loadavg()` function reads `/proc/loadavg` and calculates per-core load
• **Configurable Thresholds**: Environment variables for `LOAD_THRESHOLD` (0.8), `LOAD_RESUME_THRESHOLD` (0.5), `LOAD_CHECK_ENABLED` (true)
• **Automatic Pausing**: CPU workers pause when load exceeds threshold, resume when it drops below resume threshold
• **EMA Smoothing**: Load average integrated into existing exponential moving average system
• **Enhanced Logging**: Load status included in periodic telemetry output
• **Comprehensive Tests**: Full test coverage for load average functionality in `tests/test_loadavg.py`
• **Updated Documentation**: README includes load monitoring section and configuration examples

## Technical Details
• Per-core load calculation: `load_1min / cpu_count` for accurate threshold comparison
• Hysteresis behavior: Different pause/resume thresholds prevent oscillation
• Zero overhead when disabled via `LOAD_CHECK_ENABLED=false`
• Robust error handling for systems without `/proc/loadavg`

## Test Plan
- [x] Unit tests for `read_loadavg()` function with various scenarios
- [x] Manual verification of load monitoring integration
- [x] Syntax validation and compilation checks
- [x] Documentation review and examples
- [ ] Integration testing on Linux system with `/proc/loadavg`
- [ ] Performance testing under load